### PR TITLE
RDKOSS-82: Remove Buildscripts temporarily

### DIFF
--- a/rdk-arm.xml
+++ b/rdk-arm.xml
@@ -3,10 +3,6 @@
   <yocto version="kirkstone" />
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="buildscripts" name="build-scripts" path="scripts" remote="rdkcentral" revision="develop">
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_SCRIPTS"/>
-  </project>
-
   <project groups="layers" name="meta-rdk-auxiliary" path="rdke/common/meta-rdk-auxiliary" remote="rdkcentral" revision="develop">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_AUXILIARY"/>
   </project>


### PR DESCRIPTION
Reason for change: Removing build-scripts as it has a bug while including it through submanifest. Hence removing it temporarily , will be added back along with the buildscripts original fix.

Signed-off-by: Arjun [arjun_daasuramdass@comcast.com](mailto:arjun_daasuramdass@comcast.com)