### PR TITLE
RDKOSS-205: Update OSS manifest

### DIFF
--- a/rdk-oss-generic-arm.xml
+++ b/rdk-oss-generic-arm.xml
@@ -20,7 +20,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_PRODUCT_LAYER"/>
   </project>
 
-  <project groups="layers" name="meta-rdk-oss-reference" path="rdke/common/meta-rdk-oss-reference" remote="rdkcentral" revision="refs/tags/1.1.0">
+  <project groups="layers" name="meta-rdk-oss-reference" path="rdke/common/meta-rdk-oss-reference" remote="rdkcentral" revision="875eaadcffa4872d0983d4d6ffa147a078b5033a">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_COMMON_OSS_REFERENCE"/>
   </project>
 


### PR DESCRIPTION
Reason for change: Update the OSS manifest to avoid build issues by pointing the OSS repositories to the latest develop branch.