### PR TITLE
RDKE-785:Downgrade meta-stack-layering-support

### DIFF
--- a/rdk-oss-generic-arm.xml
+++ b/rdk-oss-generic-arm.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_AUXILIARY"/>
   </project>
 
-  <project groups="stacklayering" name="meta-stack-layering-support" path="rdke/common/meta-stack-layering-support" remote="rdkcentral" revision="refs/tags/1.2.1">
+  <project groups="stacklayering" name="meta-stack-layering-support" path="rdke/common/meta-stack-layering-support" remote="rdkcentral" revision="refs/tags/1.2.0">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_STACK_LAYERING_SUPPORT" />
   </project>
 


### PR DESCRIPTION
Reason for change: To stick with the older release and to update only poky, we are downgrading meta-stack-layering-support to 1.2.0. After tagging , this will be reverted back to 1.2.1