### PR TITLE
RDKE-785:Update meta-stack-layering-support to 1.2.1 tag

### DIFF
--- a/rdk-oss-generic-arm.xml
+++ b/rdk-oss-generic-arm.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_AUXILIARY"/>
   </project>
 
-  <project groups="stacklayering" name="meta-stack-layering-support" path="rdke/common/meta-stack-layering-support" remote="rdkcentral" revision="refs/tags/1.2.0">
+  <project groups="stacklayering" name="meta-stack-layering-support" path="rdke/common/meta-stack-layering-support" remote="rdkcentral" revision="refs/tags/1.2.1">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_STACK_LAYERING_SUPPORT" />
   </project>
 


### PR DESCRIPTION
Reason for change: Reverting back the downgrade and retaining the latest tag for meta-stack-layering-support.