### PR TITLE
RDKE-840 : Update manifest to use tag 4.6.4 of meta-rdk-oss-reference

### DIFF
--- a/rdk-oss-generic-arm.xml
+++ b/rdk-oss-generic-arm.xml
@@ -20,7 +20,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_PRODUCT_LAYER"/>
   </project>
 
-  <project groups="layers" name="meta-rdk-oss-reference" path="rdke/common/meta-rdk-oss-reference" remote="rdkcentral" revision="refs/tags/4.6.3">
+  <project groups="layers" name="meta-rdk-oss-reference" path="rdke/common/meta-rdk-oss-reference" remote="rdkcentral" revision="refs/tags/4.6.4">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_COMMON_OSS_REFERENCE"/>
   </project>
 


### PR DESCRIPTION
Update manifest to use tag 4.6.4 of meta-rdk-oss-reference